### PR TITLE
Cleaning of split_subcube.py using pylint

### DIFF
--- a/workflow/scripts/split_subcube.py
+++ b/workflow/scripts/split_subcube.py
@@ -1,7 +1,26 @@
-import sys
+# This file is part of Hi-FRIENDS SDC2
+# (https://github.com/HI-FRIENDS-SDC2/hi-friends).
+# Copyright (c) 2021 Javier Moldón
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+'''
+This script splits the cube in different subcubes according to a grid of subcubes
+'''
+
+import argparse
 import numpy as np
 from spectral_cube import SpectralCube
-import argparse
 from astropy import units as u
 
 def get_args():
@@ -10,23 +29,43 @@ def get_args():
     description = 'Split subcube identified by an index'
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument('-i', '--index', dest='idx', help='Subcube index')
-    parser.add_argument('-d', '--datacube', dest='datacube', help='Data cube to process.')
-    parser.add_argument('-c', '--coord', dest='coord_file', help='File with edge coordinates of subcubes')
+    parser.add_argument('-d', '--datacube', dest='datacube', \
+                        help='Data cube to process.')
+    parser.add_argument('-c', '--coord', dest='coord_file', \
+                        help='File with edge coordinates of subcubes')
     args = parser.parse_args()
     return args
 
 def split_subcube(infile, coord_subcubes, idx):
+    '''Creates a fits file containing the coordinates
+    x low x high y low and y high:wç
+    Parameters
+    ----------
+    infile: str
+        Input file name
+    coord_subcubes: array
+        Array containing coordinates of subcubes
+    idx: int
+        Index of subcube
+    Returns
+    -------
+    ****
+    Examples
+    --------
+    ****
+    '''
     print(f'Now exporting item {idx}')
     print(coord_subcubes[idx])
-    c = coord_subcubes[idx]
-    
+    cidx = coord_subcubes[idx]
+
     cube = SpectralCube.read(infile)
-    sub_cube = cube.subcube(xlo=c[0]*u.deg, xhi=c[2]*u.deg,
-                            ylo=c[1]*u.deg, yhi=c[3]*u.deg)
+    sub_cube = cube.subcube(xlo=cidx[0]*u.deg, xhi=cidx[2]*u.deg,
+                            ylo=cidx[1]*u.deg, yhi=cidx[3]*u.deg)
     #sub_cube.write(f'interim/subcubes/subcube_{idx:02d}.fits')
     sub_cube.write(f'interim/subcubes/subcube_{idx}.fits')
 
 def main():
+    '''Splits the data cube in several subcubes'''
     args = get_args()
     idx = int(args.idx)
     infile = args.datacube
@@ -37,6 +76,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-
-
-


### PR DESCRIPTION
Initial: Your code has been rated at 0.00/10 

Final: Your code has been rated at 2.50/10
************* Module split_subcube
split_subcube.py:62:40: E1101: Module 'astropy.units' has no 'deg' member; maybe 'dex'? (no-member)
split_subcube.py:62:59: E1101: Module 'astropy.units' has no 'deg' member; maybe 'dex'? (no-member)
split_subcube.py:63:40: E1101: Module 'astropy.units' has no 'deg' member; maybe 'dex'? (no-member)
split_subcube.py:63:59: E1101: Module 'astropy.units' has no 'deg' member; maybe 'dex'? (no-member)

It looks like there is a bug in Pylint with satrapy.units 'deg'