### PR TITLE
Cleaning filter_calaog.py with Pylint

### DIFF
--- a/workflow/scripts/filter_catalog.py
+++ b/workflow/scripts/filter_catalog.py
@@ -20,7 +20,6 @@ This script filters the output catalog based on some conditions
 
 import argparse
 import numpy as np
-from astropy.wcs import WCS
 from astropy import constants as const
 from astropy.cosmology import FlatLambdaCDM
 import astropy.units as u
@@ -37,11 +36,11 @@ def get_args():
     args = parser.parse_args()
     return args
 
-def arcsec2kpc(z, theta):
-    '''Converts angular size to linear size given a redshift z
+def arcsec2kpc(redshift, theta):
+    '''Converts angular size to linear size given a redshift
     Parameters
     ----------
-    z: float
+    redshift: float
         redshift
     theta: array of floats
         angular size in arcsec
@@ -51,11 +50,11 @@ def arcsec2kpc(z, theta):
         linear size in kpc
     '''
     cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
-    d_A = cosmo.angular_diameter_distance(z=z)
-    distance_kpc = (theta*u.arcsec * d_A).to(u.kpc, u.dimensionless_angles())
+    d_a = cosmo.angular_diameter_distance(z=redshift)
+    distance_kpc = (theta*u.arcsec * d_a).to(u.kpc, u.dimensionless_angles())
     return distance_kpc
 
-def compute_D_M(cat):
+def compute_d_m(cat):
     '''Computes the Mass of HI and linear diameter of the galaxies in a catalog
     Parameters
     ----------
@@ -68,31 +67,31 @@ def compute_D_M(cat):
     '''
     cspeed = const.c.value/1000      # km/s
     h_small = 0.7
-    f0_HI = 1420405751.786
+    f0_hi = 1420405751.786
     size = cat['hi_size'] # arcsec
-    z = (f0_HI-cat['central_freq'])/cat['central_freq']
-    distance_kpc = arcsec2kpc(z.values, size.values)
+    redshift = (f0_hi-cat['central_freq'])/cat['central_freq']
+    distance_kpc = arcsec2kpc(redshift.values, size.values)
 
     # Equation (37) of https://arxiv.org/pdf/1705.04210.pdf
-    flux_Jy_km_s = cat['line_flux_integral']*(cspeed*(1+z)**2)/f0_HI 
+    flux_jy_km_s = cat['line_flux_integral']*(cspeed*(1+redshift)**2)/f0_hi
     vel = (cat['central_freq'].values * u.Hz).to(u.km / u.s,
-           equivalencies=freq_to_vel()) 
-    distance_Mpc = vel/70
-    M_HI_units = (1/h_small**2)*235600*flux_Jy_km_s*(distance_Mpc*h_small)**2
-    D_HI_kpc = np.array(distance_kpc)
-    M_HI = np.array(M_HI_units)
-    cat['logM'] = np.log10(M_HI)
-    cat['logD'] = np.log10(D_HI_kpc)
+           equivalencies=freq_to_vel())
+    distance_mpc = vel/70
+    m_hi_units = (1/h_small**2)*235600*flux_jy_km_s*(distance_mpc*h_small)**2
+    d_hi_kpc = np.array(distance_kpc)
+    m_hi = np.array(m_hi_units)
+    cat['logM'] = np.log10(m_hi)
+    cat['logD'] = np.log10(d_hi_kpc)
     return cat
 
-def filter_MD(df_MD, uplim=0.45, downlim=-0.15):
-    ''' Removes items from a catalog based on distance from the 
+def filter_md(df_md, uplim=0.45, downlim=-0.15):
+    ''' Removes items from a catalog based on distance from the
     Wang et al. 2016 2016MNRAS.460.2143W correlation. The values used
     are log DHI= (0.506±0.003) log MHI−(3.293±0.009)
 
     Parameters
     ----------
-    df_MD: pandas DataFrame
+    df_md: pandas DataFrame
         input catalog in pandas format
     uplim: float
         Threshold distance to consider outliers in the top region
@@ -103,47 +102,45 @@ def filter_MD(df_MD, uplim=0.45, downlim=-0.15):
     df_out: pandas DataFrame
         output catalog without the outliers
     '''
-    cond1 = (df_MD['logD'] - (0.506 * df_MD['logM'] -3.293)) < downlim
-    cond2 = (df_MD['logD'] - (0.506 * df_MD['logM'] -3.293)) > uplim
+    cond1 = (df_md['logD'] - (0.506 * df_md['logM'] -3.293)) < downlim
+    cond2 = (df_md['logD'] - (0.506 * df_md['logM'] -3.293)) > uplim
     cond=cond1 | cond2
-    df_out = df_MD[~cond]
+    df_out = df_md[~cond]
     return df_out
 
-def freq_to_vel(f0=1420405751.786):
+def freq_to_vel(f0_hi=1420405751.786):
     '''Convers line frequency to velocity in km/s
 
     Parameters
     ----------
-    f0: float
+    f0_hi: float
         rest frequency of the spectral line
     Returns
     -------
     freq2vel: function
         function to convert frequency in Hz to velocity
     '''
-    restfreq = f0 * u.Hz
+    restfreq = f0_hi * u.Hz
     freq2vel = u.doppler_radio(restfreq)
     return freq2vel
 
 def main():
     '''Gets an input catalog and filters the sources based on deviation
     from the D_HI M_HI correlation'''
-    cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
     args = get_args()
-    df = pd.read_csv(args.infile, delimiter=' ')
-    df_MD = compute_D_M(df)
-    df_MD_file = (args.infile).replace('.csv', '_logMD.csv')
-    df_MD.to_csv(df_MD_file, sep=' ', index=False)
+    dataf = pd.read_csv(args.infile, delimiter=' ')
+    dataf_md = compute_d_m(dataf)
+    dataf_md_file = (args.infile).replace('.csv', '_logMD.csv')
+    dataf_md.to_csv(dataf_md_file, sep=' ', index=False)
     # Filter based of correlation
-    df_filtered = filter_MD(df_MD)
-    df_filtered.to_csv(df_MD_file.replace('.csv', '_filtered.csv'),
+    dataf_filtered = filter_md(dataf_md)
+    dataf_filtered.to_csv(dataf_md_file.replace('.csv', '_filtered.csv'),
         sep=' ', index=False)
-    df_filtered = df_filtered.drop(columns=['logM', 'logD'])
-    print(f'Number of entried before filtering: {len(df_MD)}')
-    print(f'Number of entried after  filtering: {len(df_filtered)}')
-    df_filtered.to_csv(args.outfile, sep=' ', index=False)
+    dataf_filtered = dataf_filtered.drop(columns=['logM', 'logD'])
+    print(f'Number of entried before filtering: {len(dataf_md)}')
+    print(f'Number of entried after  filtering: {len(dataf_filtered)}')
+    dataf_filtered.to_csv(args.outfile, sep=' ', index=False)
 
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION

Final: 

(base) MacBook-Air-Laura:scripts laura$ pylint filter_catalog.py --disable no-member
------------------------------------------------------------------
Your code has been rated at 10.00/10 

(base) MacBook-Air-Laura:scripts laura$ pylint filter_catalog.py 
************* Module filter_catalog
filter_catalog.py:54:26: E1101: Module 'astropy.units' has no 'arcsec' member (no-member)
filter_catalog.py:54:45: E1101: Module 'astropy.units' has no 'kpc' member (no-member)
filter_catalog.py:68:13: E1101: Module 'astropy.constants' has no 'c' member (no-member)
filter_catalog.py:77:40: E1101: Module 'astropy.units' has no 'Hz' member (no-member)
filter_catalog.py:77:49: E1101: Module 'astropy.units' has no 'km' member (no-member)
filter_catalog.py:123:23: E1101: Module 'astropy.units' has no 'Hz' member (no-member)
------------------------------------------------------------------
Your code has been rated at 4.83/10 

initial: 


(base) MacBook-Air-Laura:scripts laura$ pylint filter_catalog.py 
************* Module filter_catalog
filter_catalog.py:77:68: C0303: Trailing whitespace (trailing-whitespace)
filter_catalog.py:79:39: C0303: Trailing whitespace (trailing-whitespace)
filter_catalog.py:89:63: C0303: Trailing whitespace (trailing-whitespace)
filter_catalog.py:149:0: C0305: Trailing newlines (trailing-newlines)
filter_catalog.py:40:0: C0103: Argument name "z" doesn't conform to snake_case naming style (invalid-name)
filter_catalog.py:54:4: C0103: Variable name "d_A" doesn't conform to snake_case naming style (invalid-name)
filter_catalog.py:55:26: E1101: Module 'astropy.units' has no 'arcsec' member (no-member)
filter_catalog.py:55:45: E1101: Module 'astropy.units' has no 'kpc' member (no-member)
filter_catalog.py:58:0: C0103: Function name "compute_D_M" doesn't conform to snake_case naming style (invalid-name)
filter_catalog.py:69:13: E1101: Module 'astropy.constants' has no 'c' member (no-member)
filter_catalog.py:71:4: C0103: Variable name "f0_HI" doesn't conform to snake_case naming style (invalid-name)
filter_catalog.py:73:4: C0103: Variable name "z" doesn't conform to snake_case naming style (invalid-name)
filter_catalog.py:77:4: C0103: Variable name "flux_Jy_km_s" doesn't conform to snake_case naming style (invalid-name)
filter_catalog.py:78:40: E1101: Module 'astropy.units' has no 'Hz' member (no-member)
filter_catalog.py:78:49: E1101: Module 'astropy.units' has no 'km' member (no-member)
filter_catalog.py:80:4: C0103: Variable name "distance_Mpc" doesn't conform to snake_case naming style (invalid-name)
filter_catalog.py:81:4: C0103: Variable name "M_HI_units" doesn't conform to snake_case naming style (invalid-name)
filter_catalog.py:82:4: C0103: Variable name "D_HI_kpc" doesn't conform to snake_case naming style (invalid-name)
filter_catalog.py:83:4: C0103: Variable name "M_HI" doesn't conform to snake_case naming style (invalid-name)
filter_catalog.py:88:0: C0103: Function name "filter_MD" doesn't conform to snake_case naming style (invalid-name)
filter_catalog.py:88:0: C0103: Argument name "df_MD" doesn't conform to snake_case naming style (invalid-name)
filter_catalog.py:112:0: C0103: Argument name "f0" doesn't conform to snake_case naming style (invalid-name)
filter_catalog.py:124:20: E1101: Module 'astropy.units' has no 'Hz' member (no-member)
filter_catalog.py:133:4: C0103: Variable name "df" doesn't conform to snake_case naming style (invalid-name)
filter_catalog.py:134:4: C0103: Variable name "df_MD" doesn't conform to snake_case naming style (invalid-name)
filter_catalog.py:135:4: C0103: Variable name "df_MD_file" doesn't conform to snake_case naming style (invalid-name)
filter_catalog.py:131:4: W0612: Unused variable 'cosmo' (unused-variable)
filter_catalog.py:23:0: W0611: Unused WCS imported from astropy.wcs (unused-import)
-----------------------------------
Your code has been rated at 1.33/10

